### PR TITLE
Added workflow that builds and packages collector upon merge of a release branch

### DIFF
--- a/.github/workflows/release_pr.yaml
+++ b/.github/workflows/release_pr.yaml
@@ -1,0 +1,133 @@
+name: Merge Release Branch
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  versioning:
+    name: Determine Release Version
+    runs-on: macos-latest
+    outputs:
+      new_version: ${{ steps.extract-version.outputs.new_version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Extract version from merged branch
+        id: extract-version
+        run: |
+          BRANCH_NAME="${{ github.event.pull_request.head.ref }}"
+          echo "Merged Branch: $BRANCH_NAME"
+
+          if [[ "$BRANCH_NAME" =~ ^release/v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            VERSION=$(echo "$BRANCH_NAME" | sed 's/^release\/v//')
+            echo "Version: $VERSION"
+            echo "new_version=$VERSION" >> $GITHUB_ENV
+            echo "::set-output name=new_version::$VERSION"
+            echo "$new_version"
+          else
+            echo "Branch name does not match expected pattern (release/x.y.z). Exiting"
+            exit 1
+          fi
+
+      - name: List changes
+        run: |
+          echo "Changed files in this release:"
+          git diff --name-status HEAD^ HEAD
+
+      - name: Check if version tag exists
+        run: "if git rev-parse \"refs/tags/v$new_version\" >/dev/null 2>&1; then\n  echo \"Tag $new_version already exists. Skipping release.\"         \n  exit 0\nfi\n"
+
+      - name: Create and push tag
+        run: |
+          echo "v$new_version"
+          git tag "v$new_version"
+          git push origin "v$new_version"
+
+  build:
+    name: Package OpenTelemetry Collector
+    needs: versioning
+    runs-on: macos-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Go Setup
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.21"
+
+      - name: Verify Go installation
+        run: go version
+
+      - name: Set up environment
+        run: |
+          mkdir -p bin
+          curl -Lo bin/ocb https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv0.118.0/ocb_0.118.0_darwin_arm64
+          chmod +x bin/ocb
+
+      - name: Build Collector
+        run: |
+          ./bin/ocb --config builder-config.yaml
+
+      - name: Create Executable Script for Collector
+        run: |
+          echo "#!/bin/bash" > run_otel_collector.sh
+          echo "echo \"Starting Collector...\"" >> run_otel_collector.sh
+          echo "./otelcol-dev/otelcol-dev --config config.yaml" >> run_otel_collector.sh
+          mv run_otel_collector.sh run_otel_collector.command
+          chmod +x run_otel_collector.command
+
+      - name: Package Files
+        run: |
+          mkdir -p collector
+          mv otelcol-dev config.yaml collector/
+          mv run_otel_collector.command collector/
+          tar -czvf "instana-otel-collector-release-v${{ needs.versioning.outputs.new_version }}.tar.gz" collector .
+
+      - name: Upload release artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: "instana-otel-collector-release-v${{ needs.versioning.outputs.new_version }}"
+          path: "instana-otel-collector-release-v${{ needs.versioning.outputs.new_version }}.tar.gz"
+
+  release:
+    name: Package and Release on GitHub
+    needs: [build, versioning]
+    runs-on: macos-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: "instana-otel-collector-release-v${{ needs.versioning.outputs.new_version }}"
+
+      - name: Create GitHub Release
+        id: create-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        with:
+          tag_name: "v${{ needs.versioning.outputs.new_version }}"
+          release_name: "v${{ needs.versioning.outputs.new_version }}"
+          draft: false
+          prerelease: false
+          generate_release_notes: true
+
+      - name: Upload release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        with:
+          upload_url: ${{ steps.create-release.outputs.upload_url }}
+          asset_path: "instana-otel-collector-release-v${{ needs.versioning.outputs.new_version }}.tar.gz"
+          asset_name: "instana-otel-collector-release-v${{ needs.versioning.outputs.new_version }}.tar.gz"
+          asset_content_type: application/gzip


### PR DESCRIPTION
This workflow triggers whenever a release branch is merged into main and serves to packages a version of the collector that can be downloaded and run on MacOS.