### PR TITLE
Temporarily removing opamp functionality

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -11,10 +11,10 @@ processors:
   - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.118.0
 receivers:
   - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.118.0
-extensions:
-  - gomod:
-      github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
-      v0.118.0
+# extensions:
+#   - gomod:
+#       github.com/open-telemetry/opentelemetry-collector-contrib/extension/opampextension
+#       v0.118.0
 providers:
   - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.18.0
   - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.18.0

--- a/config.yaml
+++ b/config.yaml
@@ -32,11 +32,11 @@ service:
   telemetry:
     logs:
       level: debug
-  extensions: [opamp]
-extensions:
-  opamp:
-    server:
-      ws:
-        endpoint: ws://127.0.0.1:4320/v1/opamp
-        tls:
-          insecure_skip_verify: true
+#   extensions: [opamp]
+# extensions:
+#   opamp:
+#     server:
+#       ws:
+#         endpoint: ws://127.0.0.1:4320/v1/opamp
+#         tls:
+#           insecure_skip_verify: true


### PR DESCRIPTION
OpAmp is a feature that we do not want to include in our MVP. For this reason we are temporarily removing it from the collector by commenting/deleting any OpAmp related functionality. Currently we only have the extension plugin but this PR aims to remove this.