### PR TITLE
Add step for generating latest installer on release

### DIFF
--- a/.github/workflows/release_publish.yaml
+++ b/.github/workflows/release_publish.yaml
@@ -53,12 +53,21 @@ jobs:
         run: |
           echo "Running packaging script for version: ${{ needs.versioning.outputs.version }}"
           ./tools/packaging/linux/package_instana_collector.sh ${{ needs.versioning.outputs.version }}
+          cp instana-collector-installer-v${{ needs.versioning.outputs.version }}.sh instana-collector-installer-latest.sh
           ls -a
 
-      - name: Upload Generated Files
+      - name: Upload Versioned Installer
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
-          echo "Uploading generated files..."
+          echo "Uploading versioned files..."
           gh release upload ${{ github.ref_name }} instana-collector-installer-v${{ needs.versioning.outputs.version }}.sh
-          echo "Uploaded installer"
+          echo "Uploaded versioned installer"
+
+      - name: Upload Latest Installer
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          echo "Uploading latest files..."
+          gh release upload ${{ github.ref_name }} instana-collector-installer-latest.sh
+          echo "Uploaded latest installer"


### PR DESCRIPTION
Setup release workflow so that it generates a latest installer as well as the versioned installer, so that the curl command can just be pointed to latest and will always download the latest installer