### PR TITLE
Change default otlp/grpc endpoint to localhost

### DIFF
--- a/config/linux/config.yaml
+++ b/config/linux/config.yaml
@@ -3,7 +3,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: localhost:24317 # By default port is opened locally
+        endpoint: localhost:24317 # By default only host system has access
   filelog:
     include: ["/var/log/*.log"]
     include_file_path: true

--- a/config/linux/config.yaml
+++ b/config/linux/config.yaml
@@ -3,7 +3,7 @@ receivers:
   otlp:
     protocols:
       grpc:
-        endpoint: 0.0.0.0:24317
+        endpoint: localhost:24317 # By default port is opened locally
   filelog:
     include: ["/var/log/*.log"]
     include_file_path: true


### PR DESCRIPTION
Before the otlp/grpc endpoint was accessible to all network devices which could cause some security problems in the future. As a preventative measure, we have changed this so that it only the host system is able to access it.