### PR TITLE
Add arm64 build support

### DIFF
--- a/.github/workflows/release_publish.yaml
+++ b/.github/workflows/release_publish.yaml
@@ -37,37 +37,70 @@ jobs:
           fi
           echo "Version format is valid: $VERSION"
   packaging:
-    name: Package and upload release
+    name: Package and upload release (linux/${{ matrix.arch }})
     needs: versioning
     runs-on: ubuntu-latest
+    strategy:
+      # Publish whichever architectures succeed rather than failing the whole
+      # release if one arch has a problem.
+      fail-fast: false
+      matrix:
+        arch: [amd64, arm64, s390x]
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v3
 
+      # Read the Go version from go.mod so this cannot drift from the module
+      # requirement. Cross-compilation needs no extra tooling because the
+      # packaging script builds with CGO_ENABLED=0.
       - name: Go Setup
         uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version-file: cmd/idot_linux/go.mod
 
       - name: Create Release Artifact
+        env:
+          VERSION: ${{ needs.versioning.outputs.version }}
+          ARCH: ${{ matrix.arch }}
         run: |
-          echo "Running packaging script for version: ${{ needs.versioning.outputs.version }}"
-          ./tools/packaging/linux/package_instana_collector.sh ${{ needs.versioning.outputs.version }}
-          cp instana-collector-installer-v${{ needs.versioning.outputs.version }}.sh instana-collector-installer-latest.sh
+          echo "Running packaging script for version: $VERSION (linux/$ARCH)"
+          ./tools/packaging/linux/package_instana_collector.sh --arch "$ARCH" "$VERSION"
           ls -a
 
       - name: Upload Versioned Installer
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          VERSION: ${{ needs.versioning.outputs.version }}
+          ARCH: ${{ matrix.arch }}
         run: |
           echo "Uploading versioned files..."
-          gh release upload ${{ github.ref_name }} instana-collector-installer-v${{ needs.versioning.outputs.version }}.sh
+          gh release upload "${{ github.ref_name }}" "instana-collector-installer-v${VERSION}-linux-${ARCH}.sh"
           echo "Uploaded versioned installer"
 
       - name: Upload Latest Installer
         env:
           GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          VERSION: ${{ needs.versioning.outputs.version }}
+          ARCH: ${{ matrix.arch }}
         run: |
           echo "Uploading latest files..."
-          gh release upload ${{ github.ref_name }} instana-collector-installer-latest.sh
+          cp "instana-collector-installer-v${VERSION}-linux-${ARCH}.sh" "instana-collector-installer-latest-linux-${ARCH}.sh"
+          gh release upload "${{ github.ref_name }}" "instana-collector-installer-latest-linux-${ARCH}.sh"
           echo "Uploaded latest installer"
+
+      # Backward compatibility: before this change, release assets carried no
+      # architecture suffix and were always amd64. Keep publishing those exact
+      # names for amd64 so existing download URLs and automation keep working.
+      - name: Upload legacy unsuffixed assets (amd64 only)
+        if: matrix.arch == 'amd64'
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          VERSION: ${{ needs.versioning.outputs.version }}
+        run: |
+          echo "Uploading legacy unsuffixed asset names for backward compatibility..."
+          cp "instana-collector-installer-v${VERSION}-linux-amd64.sh" "instana-collector-installer-v${VERSION}.sh"
+          cp "instana-collector-installer-v${VERSION}-linux-amd64.sh" "instana-collector-installer-latest.sh"
+          gh release upload "${{ github.ref_name }}" \
+            "instana-collector-installer-v${VERSION}.sh" \
+            "instana-collector-installer-latest.sh"
+          echo "Uploaded legacy assets"

--- a/README.md
+++ b/README.md
@@ -31,20 +31,26 @@ Visit the [IBM OpenTelemetry Documentation](https://www.ibm.com/docs/en/instana-
 
 The Instana Distribution of OpenTelemetry Collector supports the following architectures:
 
-| OS      | Architectures                 |
-|---------|-------------------------------|
-| Linux   | x86-64 (amd64), s390x (IBM Z) |
-| Windows | x86-64 (amd64)                |
+| OS      | Architectures                                 |
+|---------|-----------------------------------------------|
+| Linux   | x86-64 (amd64), arm64 (AArch64), s390x (IBM Z)|
+| Windows | x86-64 (amd64)                                |
 
 ### Linux Installation
 
-The installation process is identical for both supported Linux architectures (amd64 and s390x/IBM Z). The only difference is the installer script you need to download.
+The installation process is identical for all supported Linux architectures (amd64, arm64/AArch64 and s390x/IBM Z). The only difference is the installer script you need to download.
 
 #### Step 1: Download the appropriate installer for your architecture
 
 **For x86-64/amd64 systems:**
 ```bash
 curl -Lo instana_otelcol_setup.sh https://github.com/instana/instana-otel-collector/releases/latest/download/instana-otel-collector-installer-latest-linux-amd64.sh
+chmod +x instana_otelcol_setup.sh
+```
+
+**For arm64/AArch64 systems (for example AWS Graviton):**
+```bash
+curl -Lo instana_otelcol_setup.sh https://github.com/instana/instana-otel-collector/releases/latest/download/instana-otel-collector-installer-latest-linux-arm64.sh
 chmod +x instana_otelcol_setup.sh
 ```
 

--- a/cmd/idot_linux/components.go
+++ b/cmd/idot_linux/components.go
@@ -86,7 +86,6 @@ func components() (otelcol.Factories, error) {
 		zipkinreceiver.NewFactory(),
 		jaegerreceiver.NewFactory(),
 		awscloudwatchreceiver.NewFactory(),
-		shellreceiver.NewFactory(),
 	)
 	if err != nil {
 		return otelcol.Factories{}, err

--- a/docs/building.md
+++ b/docs/building.md
@@ -1,0 +1,87 @@
+# Building IDOT from source
+
+The Linux installer is produced by `tools/packaging/linux/package_instana_collector.sh`.
+It builds the collector binary, assembles the `collector/` tree (binary, service
+scripts and example config) and emits a self-extracting installer with the
+tarball embedded.
+
+## Prerequisites
+
+- Go (version as declared in `cmd/idot_linux/go.mod`)
+- `tar`, `base64`, `sed`
+- ~500 MB free disk space
+
+No C toolchain is required. The collector is built with `CGO_ENABLED=0`, which
+means it is statically linked and can be cross-compiled for any supported
+architecture from any build host.
+
+## Usage
+
+```bash
+./tools/packaging/linux/package_instana_collector.sh [OPTIONS] <version>
+```
+
+| Option | Description |
+|--------|-------------|
+| `-a`, `--arch` | Target architecture: `amd64` (default), `arm64`, `s390x`. Also settable via the `ARCH` environment variable. |
+| `-v`, `--verbose` | Verbose output |
+| `-d`, `--dry-run` | Run without making changes |
+| `-h`, `--help` | Show help |
+| `--version` | Show script version |
+
+## Examples
+
+```bash
+# amd64 (default)
+./tools/packaging/linux/package_instana_collector.sh 1.2.3
+
+# arm64 / AArch64
+./tools/packaging/linux/package_instana_collector.sh --arch arm64 1.2.3
+
+# s390x / IBM Z
+./tools/packaging/linux/package_instana_collector.sh --arch s390x 1.2.3
+
+# architecture via environment
+ARCH=arm64 ./tools/packaging/linux/package_instana_collector.sh 1.2.3
+```
+
+## Output
+
+```
+instana-collector-installer-v<version>-linux-<arch>.sh
+instana-otel-collector-release-v<version>-linux-<arch>.tar.gz.sha256
+```
+
+Artifact names are architecture-qualified so builds for multiple architectures
+can be attached to the same release without colliding.
+
+## Verifying the result
+
+Confirm the embedded binary targets the architecture you asked for:
+
+```bash
+./instana-collector-installer-v1.2.3-linux-arm64.sh \
+  -e <endpoint> -a <key> -s /tmp/verify
+file /tmp/verify/collector/bin/instana-otelcol
+# ELF 64-bit LSB executable, ARM aarch64, ... statically linked, stripped
+```
+
+The `-s` flag extracts without installing the systemd service, which makes this
+safe to run on a build machine.
+
+List the compiled-in components:
+
+```bash
+/tmp/verify/collector/bin/instana-otelcol components
+```
+
+## Release automation
+
+`.github/workflows/release_publish.yaml` runs the packaging script across an
+architecture matrix and uploads one installer per architecture, plus a
+`-latest-linux-<arch>` alias. For backward compatibility it also publishes the
+historical unsuffixed `instana-collector-installer-v<version>.sh` and
+`instana-collector-installer-latest.sh` names, which are amd64.
+
+Because cross-compilation needs no emulation, every architecture builds on the
+standard `ubuntu-latest` runner — no QEMU and no native ARM or Z runners.

--- a/tools/packaging/linux/package_instana_collector.sh
+++ b/tools/packaging/linux/package_instana_collector.sh
@@ -3,12 +3,18 @@
 # Exit on error, undefined variables, and pipe failures
 set -euo pipefail
 
-SCRIPT_VERSION="1.0.0"
+SCRIPT_VERSION="1.1.0"
 VERSION=""
 VERBOSE=false
 DRY_RUN=false
 SUPERVISOR=false
 TEMP_DIR=""
+# Target architecture for the build. Overridable via --arch or the ARCH env var.
+# Defaults to amd64 to preserve the previous behaviour of this script.
+ARCH="${ARCH:-amd64}"
+# Architectures this script knows how to build. All are cross-compiled from any
+# build host because the collector is built with CGO_ENABLED=0.
+SUPPORTED_ARCHES="amd64 arm64 s390x"
 
 # Function to display script usage
 show_help() {
@@ -21,10 +27,20 @@ Options:
   -h, --help     Show this help message and exit
   -v, --verbose  Enable verbose output
   -d, --dry-run  Run without making changes
-  --version      Show script version
+  -a, --arch     Target architecture: amd64 (default), arm64 or s390x.
+                 May also be set via the ARCH environment variable.
+      --version  Show script version
 
 Arguments:
   version        Version number for the package (required)
+
+Examples:
+  $(basename "$0") 1.2.3                 # build for amd64 (default)
+  $(basename "$0") --arch arm64 1.2.3    # build for arm64
+  ARCH=arm64 $(basename "$0") 1.2.3      # same, via environment
+
+Output:
+  instana-collector-installer-v<version>-linux-<arch>.sh
 EOF
 }
 
@@ -72,6 +88,34 @@ check_dependencies() {
         log "ERROR" "Please install missing dependencies and try again."
         exit 1
     fi
+}
+
+# Function to validate the requested target architecture
+validate_arch() {
+    local valid=false
+    for supported in $SUPPORTED_ARCHES; do
+        if [[ "$ARCH" == "$supported" ]]; then
+            valid=true
+            break
+        fi
+    done
+
+    if [[ "$valid" != "true" ]]; then
+        log "ERROR" "Unsupported architecture: '$ARCH'. Supported: $SUPPORTED_ARCHES"
+        exit 1
+    fi
+
+    log "INFO" "Target architecture: linux/$ARCH"
+}
+
+# Function to configure the Go cross-compilation environment.
+# CGO is disabled so the resulting binary is statically linked and can be
+# cross-compiled for any GOARCH from any build host without a C toolchain.
+setup_build_env() {
+    export GOOS="linux"
+    export GOARCH="$ARCH"
+    export CGO_ENABLED="0"
+    log "DEBUG" "Build env: GOOS=$GOOS GOARCH=$GOARCH CGO_ENABLED=$CGO_ENABLED"
 }
 
 # Function to check available disk space
@@ -267,7 +311,7 @@ package_files() {
     
     # Create tarball
     log "DEBUG" "Creating tarball..."
-    if ! tar -czvf "instana-otel-collector-release-v$VERSION.tar.gz" collector; then
+    if ! tar -czvf "$TARBALL" collector; then
         log "ERROR" "Failed to create tarball"
         exit 1
     fi
@@ -275,9 +319,9 @@ package_files() {
     # Generate checksum
     log "DEBUG" "Generating checksum..."
     if command -v sha256sum &>/dev/null; then
-        sha256sum "instana-otel-collector-release-v$VERSION.tar.gz" > "instana-otel-collector-release-v$VERSION.tar.gz.sha256"
+        sha256sum "$TARBALL" > "$TARBALL.sha256"
     elif command -v shasum &>/dev/null; then
-        shasum -a 256 "instana-otel-collector-release-v$VERSION.tar.gz" > "instana-otel-collector-release-v$VERSION.tar.gz.sha256"
+        shasum -a 256 "$TARBALL" > "$TARBALL.sha256"
     else
         log "WARNING" "Neither sha256sum nor shasum found, skipping checksum generation"
     fi
@@ -312,18 +356,18 @@ create_installer_script() {
     fi
     
     local BASE64_TAR
-    BASE64_TAR=$($base64_cmd < "instana-otel-collector-release-v$VERSION.tar.gz")
+    BASE64_TAR=$($base64_cmd < "$TARBALL")
     
     log "DEBUG" "Creating installer script..."
     
-    cat > "instana-collector-installer-v$VERSION.sh" <<EOL
+    cat > "$INSTALLER" <<EOL
 #!/bin/bash
 
 # Exit on error, undefined variables, and pipe failures
 set -euo pipefail
 
 show_help() {
-  echo "Usage: instana-collector-installer-v$VERSION.sh -e INSTANA_OTEL_ENDPOINT_GRPC [-H INSTANA_OTEL_ENDPOINT_HTTP] [-o INSTANA_OPAMP_ENDPOINT] -a INSTANA_KEY [install_path]"
+  echo "Usage: $INSTALLER -e INSTANA_OTEL_ENDPOINT_GRPC [-H INSTANA_OTEL_ENDPOINT_HTTP] [-o INSTANA_OPAMP_ENDPOINT] -a INSTANA_KEY [install_path]"
   echo "Options:"
   echo "  -h, --help          Show this help message and exit"
   echo "  -e gRPC ENDPOINT    Set the Instana OTel gRPC endpoint (required)"
@@ -577,8 +621,8 @@ fi
 echo "Installation complete. Files are available at \$INSTALL_PATH."
 EOL
     
-    chmod +x "instana-collector-installer-v$VERSION.sh"
-    log "INFO" "Successfully created installer script: instana-collector-installer-v$VERSION.sh"
+    chmod +x "$INSTALLER"
+    log "INFO" "Successfully created installer script: $INSTALLER"
 }
 
 # Function to clean up artifacts
@@ -590,7 +634,7 @@ cleanup() {
         return 0
     fi
     
-    rm -rf otelcol-dev collector "instana-otel-collector-release-v$VERSION.tar.gz"
+    rm -rf otelcol-dev collector "$TARBALL"
     log "DEBUG" "Artifacts cleaned up"
 }
 
@@ -612,6 +656,14 @@ while [[ $# -gt 0 ]]; do
         -d|--dry-run)
             DRY_RUN=true
             shift
+            ;;
+        -a|--arch)
+            if [[ -z "${2-}" ]]; then
+                log "ERROR" "--arch requires a value ($SUPPORTED_ARCHES)"
+                exit 1
+            fi
+            ARCH="$2"
+            shift 2
             ;;
         -*)
             log "ERROR" "Unknown option: $1"
@@ -654,6 +706,17 @@ main() {
     if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
         log "WARNING" "Version '$VERSION' does not appear to follow semantic versioning (X.Y.Z)"
     fi
+
+    # Validate the target architecture and configure the Go build environment
+    validate_arch
+    setup_build_env
+
+    # Artifact names are architecture-qualified so that builds for different
+    # architectures can coexist in the same release without colliding. The
+    # "-linux-<arch>" suffix matches the download URLs already documented in
+    # README.md.
+    TARBALL="instana-otel-collector-release-v${VERSION}-linux-${ARCH}.tar.gz"
+    INSTALLER="instana-collector-installer-v${VERSION}-linux-${ARCH}.sh"
     
     # Check dependencies
     check_dependencies
@@ -685,9 +748,10 @@ main() {
     echo "----------------------------------------"
     echo "Package Summary:"
     echo "  Version: $VERSION"
-    echo "  Installer: instana-collector-installer-v$VERSION.sh"
-    if [[ -f "instana-otel-collector-release-v$VERSION.tar.gz.sha256" ]]; then
-        echo "  Checksum: $(cat "instana-otel-collector-release-v$VERSION.tar.gz.sha256")"
+    echo "  Architecture: linux/$ARCH"
+    echo "  Installer: $INSTALLER"
+    if [[ -f "$TARBALL.sha256" ]]; then
+        echo "  Checksum: $(cat "$TARBALL.sha256")"
     fi
     echo "  Supervisor included: $SUPERVISOR"
     echo "----------------------------------------"


### PR DESCRIPTION
# Add multi-architecture Linux builds (arm64, s390x)

## Problem

`tools/packaging/linux/package_instana_collector.sh` builds the collector with a
plain `go build` and no `GOOS`/`GOARCH`, so it always produces a binary for
whatever the build host happens to be. Since the release workflow runs on
`ubuntu-latest`, every published installer is amd64.

There is no way to produce an arm64 installer today, which blocks running IDOT on
AArch64 hosts (AWS Graviton, Ampere, Apple Silicon VMs, etc.).

Two related inconsistencies show up alongside this:

1. **README.md already advertises s390x**, and documents per-architecture
   download URLs of the form
   `instana-otel-collector-installer-latest-linux-<arch>.sh`. But `s390x` appears
   nowhere else in the repository — there is no build path for it in the
   packaging script, the release workflow, or the Makefile. The documented
   architecture cannot currently be produced.

2. **`Makefile` has a `%-package` target** accepting `ARCH=`, which looks like
   the intended multi-arch entry point, but it invokes
   `internal/buildscripts/packaging/fpm` — a directory that does not exist in
   this repository. This target is dead. I left it untouched rather than guess at
   its intent; happy to remove or redirect it to the real script if you'd like.

## Changes

**`tools/packaging/linux/package_instana_collector.sh`**

- New `-a` / `--arch` option, also settable via the `ARCH` environment variable.
  Accepts `amd64` (default), `arm64`, `s390x`, with validation and a clear error
  on anything else.
- Exports `GOOS=linux`, `GOARCH=$ARCH`, `CGO_ENABLED=0` for the build.
- Artifact names are architecture-qualified using the `-linux-<arch>` suffix
  **already documented in README.md**, so multiple architectures can attach to
  one release without colliding.
- Help text and the completion summary report the target architecture.

**`.github/workflows/release_publish.yaml`**

- Builds across an `[amd64, arm64, s390x]` matrix with `fail-fast: false`, so one
  architecture failing doesn't sink the whole release.
- Publishes `...-v<version>-linux-<arch>.sh` plus a
  `...-latest-linux-<arch>.sh` alias per architecture.
- **Still publishes the historical unsuffixed names**
  (`instana-collector-installer-v<version>.sh` and
  `instana-collector-installer-latest.sh`, both amd64) so existing download URLs
  and automation are unaffected.
- Go version now comes from `cmd/idot_linux/go.mod` via `go-version-file` rather
  than the hardcoded `"1.21"`, which had drifted from that module's
  `go 1.24.0` requirement.

**Docs**

- README: arm64 added to the support matrix and download steps.
- New `docs/building.md`: how to build and verify per-architecture installers.

## Why this needs no new CI infrastructure

The collector is built with `CGO_ENABLED=0`, so it's statically linked and
cross-compiles from any host. All three architectures build on the existing
`ubuntu-latest` runner — no QEMU, no native ARM or Z runners, no added cost.
Each build took roughly 15 seconds locally.

## Verification

All three architectures were built and the embedded binary in each installer
confirmed:

| `--arch` | `file` output on the extracted binary |
|----------|----------------------------------------|
| `amd64`  | `ELF 64-bit LSB executable, x86-64` |
| `arm64`  | `ELF 64-bit LSB executable, ARM aarch64` |
| `s390x`  | `ELF 64-bit MSB executable, IBM S/390` |

Each is `statically linked, stripped`. Note `s390x` is correctly big-endian
(`MSB`).

Backward compatibility checks:

- `package_instana_collector.sh 1.320.1` with no flags → `linux/amd64`
- `ARCH=arm64 package_instana_collector.sh 1.320.1` → `linux/arm64`
- Invalid arch → `ERROR: Unsupported architecture: 'ppc64'. Supported: amd64 arm64 s390x`

The arm64 installer was additionally deployed end to end on an Amazon Linux 2023
Graviton host (`m6gd.xlarge`): the installer created the systemd unit, the
collector started, the StatsD receiver bound, the `resourcedetection` processor
detected EC2 metadata, and metrics exported to Instana with zero failures.

### One intentional behavior change

The script's own output filename now always carries the `-linux-<arch>` suffix,
including for the amd64 default. Anything invoking the script directly and
expecting the old unsuffixed filename will need updating. The release workflow
compensates so that **published release asset names are unchanged**. Flagging it
explicitly since it's the one non-additive change here.

## Question on asset naming

There's a pre-existing mismatch I did not want to resolve unilaterally:

- README documents `instana-otel-collector-installer-latest-linux-<arch>.sh`
- the script and workflow produce `instana-collector-installer-...`
  (no `otel-`)

I kept the script's existing `instana-collector-installer-` prefix and only added
the architecture suffix. If the README prefix is the correct one — perhaps
matching an internal publishing pipeline — say so and I'll align the script and
workflow to it in this PR.

## Second commit: a build blocker

The second commit is separate on purpose and **may not be the right fix for
you**.

`cmd/idot_linux/components.go` calls `shellreceiver.NewFactory()`, but
`shellreceiver` has no import, is absent from `cmd/idot_linux/go.mod` and from
both `builder-config.yaml` files, has no directory in the repo, and is missing
the `factories.ReceiverModules[...]` entry that every other receiver in that list
has. A clean checkout fails:

```
./components.go:89:3: undefined: shellreceiver
```

This reproduces on `main` and on every tag from `v1.317.2` through `v1.320.2`
(all of which point at the same commit), so no tag builds from public source.

The commit removes that one line. Since `components.go` is builder-generated and
neither `builder-config.yaml` lists a shell receiver, regenerating would produce
the same result.

**However** — if `shellreceiver` exists in an internal tree that's stripped when
publishing this repo, then removing it is wrong for your build, and the real fix
is to regenerate the public `components.go` at publish time. In that case please
treat the commit purely as a bug report and drop it. The multi-architecture
commit does not depend on it and applies cleanly on its own.
